### PR TITLE
Add support for HTTP/3 to CF distribution

### DIFF
--- a/website.ts
+++ b/website.ts
@@ -339,6 +339,7 @@ function createCloudFront(
         sslSupportMethod: "sni-only",
         minimumProtocolVersion: "TLSv1.2_2021"
       },
+      httpVersion: "http2and3",
       isIpv6Enabled: true
     },
     {


### PR DESCRIPTION
See https://aws.amazon.com/blogs/aws/new-http-3-support-for-amazon-cloudfront/.